### PR TITLE
Remove diacritic signs from Israel country name

### DIFF
--- a/lib/country_codes.dart
+++ b/lib/country_codes.dart
@@ -530,7 +530,7 @@ List<Map<String, String>> codes = [
     "dial_code": "+44",
   },
   {
-    "name": "יִשְׂרָאֵל",
+    "name": "ישראל",
     "code": "IL",
     "dial_code": "+972",
   },


### PR DESCRIPTION
Users searching for Israel will never type the diacritic signs when searching for the country name.
Because the diacritics are there, a search for "ישראל" will not find the correct dial code, as this is a different Unicode string.